### PR TITLE
Add compaction to Roots

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --features sqlite
+          cargo bench --features sqlite -- --verbose
 
       - name: Generate overview
         run: |

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,6 +18,9 @@ sqlite = ["rusqlite"]
 name = "nebari-bench"
 harness = false
 
+[lib]
+bench = false
+
 [dependencies]
 nanorand = "0.6"
 anyhow = "1"

--- a/benchmarks/benches/logs/nebari.rs
+++ b/benchmarks/benches/logs/nebari.rs
@@ -61,9 +61,10 @@ impl<B: NebariBenchmark> SimpleBench for InsertLogs<B> {
         let tempfile = TempDir::new()?;
         let manager = <<StdFile as ManagedFile>::Manager as Default>::default();
         let file = manager.append(tempfile.path().join("tree"))?;
+        let state = State::initialized(file.id());
         let tree = TreeFile::<B::Root, StdFile>::new(
             file,
-            State::initialized(),
+            state,
             None,
             Some(ChunkCache::new(100, 160_384)),
         )?;
@@ -118,9 +119,10 @@ impl<B: NebariBenchmark> SimpleBench for ReadLogs<B> {
         let tempfile = TempDir::new().unwrap();
         let manager = <<StdFile as ManagedFile>::Manager as Default>::default();
         let file = manager.append(tempfile.path().join("tree")).unwrap();
+        let state = State::initialized(file.id());
         let mut tree = TreeFile::<B::Root, StdFile>::new(
             file,
-            State::initialized(),
+            state,
             None,
             Some(ChunkCache::new(2000, 160_384)),
         )
@@ -217,9 +219,10 @@ impl<B: NebariBenchmark> SimpleBench for ScanLogs<B> {
         let tempfile = TempDir::new().unwrap();
         let manager = <<StdFile as ManagedFile>::Manager as Default>::default();
         let file = manager.append(tempfile.path().join("tree")).unwrap();
+        let state = State::initialized(file.id());
         let mut tree = TreeFile::<B::Root, StdFile>::new(
             file,
-            State::initialized(),
+            state,
             None,
             Some(ChunkCache::new(2000, 160_384)),
         )

--- a/benchmarks/benches/logs/nebari.rs
+++ b/benchmarks/benches/logs/nebari.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use nebari::{
-    io::{fs::StdFile, FileManager, ManagedFile},
+    io::{fs::StdFile, FileManager, ManagedFile, OpenableFile},
     tree::{
         Modification, Operation, Root, State, TreeFile, UnversionedTreeRoot, VersionedTreeRoot,
     },
@@ -159,7 +159,14 @@ impl<B: NebariBenchmark> SimpleBench for ReadLogs<B> {
         let file_path = group_state.path().join("tree");
         let file = context.file_manager.append(&file_path).unwrap();
         let state = State::default();
-        TreeFile::<B::Root, StdFile>::initialize_state(&state, &file_path, &context, None).unwrap();
+        TreeFile::<B::Root, StdFile>::initialize_state(
+            &state,
+            &file_path,
+            file.id(),
+            &context,
+            None,
+        )
+        .unwrap();
         let tree = TreeFile::<B::Root, StdFile>::new(
             file,
             state,
@@ -251,7 +258,14 @@ impl<B: NebariBenchmark> SimpleBench for ScanLogs<B> {
         let file_path = group_state.path().join("tree");
         let file = context.file_manager.append(&file_path).unwrap();
         let state = State::default();
-        TreeFile::<B::Root, StdFile>::initialize_state(&state, &file_path, &context, None).unwrap();
+        TreeFile::<B::Root, StdFile>::initialize_state(
+            &state,
+            &file_path,
+            file.id(),
+            &context,
+            None,
+        )
+        .unwrap();
         let tree = TreeFile::<B::Root, StdFile>::new(
             file,
             state,

--- a/nebari/Cargo.toml
+++ b/nebari/Cargo.toml
@@ -23,6 +23,7 @@ parking_lot = "0.11"
 tracing = { version = "0.1", optional = true }
 ranges = "0.3"
 num_cpus = "1.13"
+backtrace = "0.3"
 
 [dev-dependencies]
 nanorand = "0.6"

--- a/nebari/src/error.rs
+++ b/nebari/src/error.rs
@@ -1,10 +1,104 @@
 use std::fmt::Display;
 
+use backtrace::Backtrace;
 use thiserror::Error;
+
+#[derive(Debug)]
+pub struct Error {
+    pub kind: ErrorKind,
+
+    pub backtrace: Backtrace,
+}
+
+impl Error {
+    pub(crate) fn data_integrity(error: impl Into<Self>) -> Self {
+        Self {
+            kind: ErrorKind::DataIntegrity(Box::new(error.into())),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.kind.source()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.kind.fmt(f)?;
+
+        #[cfg(debug_assertions)]
+        {
+            f.write_str("\nstack backtrace:")?;
+            for (index, frame) in self.backtrace.frames().iter().enumerate() {
+                write!(f, "\n#{}: {:?}", index, frame)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self {
+            kind,
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Self {
+            kind: ErrorKind::from(err),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl From<&'static str> for Error {
+    fn from(message: &'static str) -> Self {
+        Self {
+            kind: ErrorKind::message(message),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl From<flume::RecvError> for Error {
+    fn from(_err: flume::RecvError) -> Self {
+        Self {
+            kind: ErrorKind::Internal(InternalError::InternalCommunication),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl<T> From<flume::SendError<T>> for Error {
+    fn from(_err: flume::SendError<T>) -> Self {
+        Self {
+            kind: ErrorKind::Internal(InternalError::InternalCommunication),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl From<String> for Error {
+    fn from(message: String) -> Self {
+        Self {
+            kind: ErrorKind::message(message),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
 
 /// An error from [`Roots`](crate::Roots).
 #[derive(Debug, Error)]
-pub enum Error {
+#[error(transparent)]
+pub enum ErrorKind {
     /// An error has occurred. The string contains human-readable error message.
     /// This error is only used in situations where a user is not expected to be
     /// able to recover automatically from the error.
@@ -15,7 +109,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     /// An unrecoverable data integrity error was encountered.
     #[error("an unrecoverable error with the data on disk has been found: {0}")]
-    DataIntegrity(Box<Self>),
+    DataIntegrity(Box<Error>),
     /// A key was too large.
     #[error("key too large")]
     KeyTooLarge,
@@ -32,38 +126,42 @@ pub enum Error {
     /// recoverable and represent some internal error condition.
     #[error("an internal error occurred: {0}")]
     Internal(InternalError),
+    /// The underlying database file has been compacted, and the request cannot
+    /// be completed. Reopen the file and try again.
+    #[error("the file has been compacted. reopen the file and try again")]
+    DatabaseCompacted,
 }
 
-impl Error {
+impl ErrorKind {
     /// Returns a new [`Error::Message`] instance with the message provided.
     pub(crate) fn message<S: Display>(message: S) -> Self {
         Self::Message(message.to_string())
     }
 
-    pub(crate) fn data_integrity(error: impl Into<Self>) -> Self {
+    pub(crate) fn data_integrity(error: impl Into<Error>) -> Self {
         Self::DataIntegrity(Box::new(error.into()))
     }
 }
 
-impl From<&'static str> for Error {
+impl From<&'static str> for ErrorKind {
     fn from(message: &'static str) -> Self {
         Self::message(message)
     }
 }
 
-impl From<flume::RecvError> for Error {
+impl From<flume::RecvError> for ErrorKind {
     fn from(_err: flume::RecvError) -> Self {
         Self::Internal(InternalError::InternalCommunication)
     }
 }
 
-impl<T> From<flume::SendError<T>> for Error {
+impl<T> From<flume::SendError<T>> for ErrorKind {
     fn from(_err: flume::SendError<T>) -> Self {
         Self::Internal(InternalError::InternalCommunication)
     }
 }
 
-impl From<String> for Error {
+impl From<String> for ErrorKind {
     fn from(message: String) -> Self {
         Self::message(message)
     }

--- a/nebari/src/io/fs.rs
+++ b/nebari/src/io/fs.rs
@@ -219,14 +219,12 @@ impl FileManager for StdFileManager {
     }
 
     fn close_handles<F: FnOnce(u64)>(&self, path: impl AsRef<Path>, publish_callback: F) {
-        if let Some((old_id, new_id, _guard)) =
-            self.file_ids.recreate_file_id_for_path(path.as_ref())
-        {
+        if let Some(result) = self.file_ids.recreate_file_id_for_path(path.as_ref()) {
             let mut open_files = self.open_files.lock();
             let mut reader_files = self.reader_files.lock();
-            open_files.remove(&old_id);
-            reader_files.remove(&old_id);
-            publish_callback(new_id);
+            open_files.remove(&result.previous_id);
+            reader_files.remove(&result.previous_id);
+            publish_callback(result.new_id);
         }
     }
 }

--- a/nebari/src/lib.rs
+++ b/nebari/src/lib.rs
@@ -35,7 +35,7 @@ pub use self::{
     buffer::Buffer,
     chunk_cache::ChunkCache,
     context::Context,
-    error::Error,
+    error::ErrorKind,
     roots::{
         AbortError, CompareAndSwapError, Config, ExecutingTransaction, Roots, ThreadPool,
         TransactionTree, Tree,

--- a/nebari/src/lib.rs
+++ b/nebari/src/lib.rs
@@ -35,7 +35,7 @@ pub use self::{
     buffer::Buffer,
     chunk_cache::ChunkCache,
     context::Context,
-    error::ErrorKind,
+    error::{Error, ErrorKind},
     roots::{
         AbortError, CompareAndSwapError, Config, ExecutingTransaction, Roots, ThreadPool,
         TransactionTree, Tree,

--- a/nebari/src/tree/btree_entry.rs
+++ b/nebari/src/tree/btree_entry.rs
@@ -285,7 +285,9 @@ where
                     match operation {
                         KeyOperation::Set(index) => {
                             // New node.
-                            if children.capacity() < children.len() + 1 {
+                            if children.capacity() < children.len() + 1
+                                && context.current_order > children.len()
+                            {
                                 children.reserve(context.current_order - children.len());
                             }
                             children.insert(
@@ -646,8 +648,8 @@ where
             }
             BTreeNode::Uninitialized => unreachable!(),
         }
-        // Regardless of if data was copied, data locations have been updated, so the
-        // node is considered dirty.
+        // Regardless of if data was copied, data locations have been updated,
+        // so the node is considered dirty.
         self.dirty |= true;
         Ok(any_changes)
     }

--- a/nebari/src/tree/btree_entry.rs
+++ b/nebari/src/tree/btree_entry.rs
@@ -16,7 +16,10 @@ use super::{
     versioned::ChangeResult,
     KeyRange, PagedWriter,
 };
-use crate::{io::ManagedFile, tree::KeyEvaluation, AbortError, Buffer, ChunkCache, Error, Vault};
+use crate::{
+    error::Error, io::ManagedFile, tree::KeyEvaluation, AbortError, Buffer, ChunkCache, ErrorKind,
+    Vault,
+};
 
 /// A B-Tree entry that stores a list of key-`I` pairs.
 #[derive(Clone, Debug)]
@@ -195,7 +198,7 @@ where
                         Operation::SetEach(values) => (context.indexer)(
                             &key,
                             Some(&values.pop().ok_or_else(|| {
-                                Error::message("need the same number of keys as values")
+                                ErrorKind::message("need the same number of keys as values")
                             })?),
                             Some(&children[last_index].index),
                             changes,
@@ -259,7 +262,7 @@ where
                         Operation::SetEach(new_values) => (context.indexer)(
                             &key,
                             Some(&new_values.pop().ok_or_else(|| {
-                                Error::message("need the same number of keys as values")
+                                ErrorKind::message("need the same number of keys as values")
                             })?),
                             None,
                             changes,
@@ -578,7 +581,7 @@ where
                             .map_loaded_entry(file, vault, cache, children.len(), |entry, file| {
                                 entry
                                     .get(keys, key_evaluator, key_reader, file, vault, cache)
-                                    .map_err(AbortError::Roots)
+                                    .map_err(AbortError::Nebari)
                             })
                             .map_err(AbortError::infallible)?;
                         if !keep_scanning {
@@ -643,7 +646,9 @@ where
             }
             BTreeNode::Uninitialized => unreachable!(),
         }
-        self.dirty |= any_changes;
+        // Regardless of if data was copied, data locations have been updated, so the
+        // node is considered dirty.
+        self.dirty |= true;
         Ok(any_changes)
     }
 }

--- a/nebari/src/tree/by_id.rs
+++ b/nebari/src/tree/by_id.rs
@@ -1,7 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use super::{btree_entry::Reducer, BinarySerialization, PagedWriter};
-use crate::{io::ManagedFile, Buffer, Error};
+use crate::{error::Error, io::ManagedFile, Buffer};
 
 #[derive(Clone, Debug)]
 pub struct VersionedByIdIndex {

--- a/nebari/src/tree/by_sequence.rs
+++ b/nebari/src/tree/by_sequence.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use super::{btree_entry::Reducer, BinarySerialization, PagedWriter};
-use crate::{io::ManagedFile, Buffer, Error};
+use crate::{error::Error, io::ManagedFile, Buffer, ErrorKind};
 
 #[derive(Clone, Debug)]
 pub struct BySequenceIndex {
@@ -25,7 +25,7 @@ impl BinarySerialization for BySequenceIndex {
         bytes_written += 8;
 
         let document_id_length =
-            u16::try_from(self.document_id.len()).map_err(|_| Error::IdTooLarge)?;
+            u16::try_from(self.document_id.len()).map_err(|_| ErrorKind::IdTooLarge)?;
         writer.write_u16::<BigEndian>(document_id_length)?;
         bytes_written += 2;
         writer.extend_from_slice(&self.document_id);

--- a/nebari/src/tree/interior.rs
+++ b/nebari/src/tree/interior.rs
@@ -11,8 +11,8 @@ use super::{
     read_chunk, BinarySerialization, PagedWriter,
 };
 use crate::{
-    chunk_cache::CacheEntry, io::ManagedFile, tree::btree_entry::NodeInclusion, AbortError, Buffer,
-    ChunkCache, Error, Vault,
+    chunk_cache::CacheEntry, error::Error, io::ManagedFile, tree::btree_entry::NodeInclusion,
+    AbortError, Buffer, ChunkCache, ErrorKind, Vault,
 };
 
 #[derive(Clone, Debug)]
@@ -241,7 +241,7 @@ impl<
         self.position = Pointer::OnDisk(location_on_disk);
         let mut bytes_written = 0;
         // Write the key
-        let key_len = u16::try_from(self.key.len()).map_err(|_| Error::KeyTooLarge)?;
+        let key_len = u16::try_from(self.key.len()).map_err(|_| ErrorKind::KeyTooLarge)?;
         writer.write_u16::<BigEndian>(key_len)?;
         writer.extend_from_slice(&self.key);
         bytes_written += 2 + key_len as usize;

--- a/nebari/src/tree/key_entry.rs
+++ b/nebari/src/tree/key_entry.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, convert::TryFrom};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use super::{serialization::BinarySerialization, PagedWriter};
-use crate::{io::ManagedFile, Buffer, Error, Vault};
+use crate::{error::Error, io::ManagedFile, Buffer, ErrorKind, Vault};
 
 #[derive(Debug, Clone)]
 pub struct KeyEntry<I> {
@@ -50,7 +50,7 @@ impl<I: BinarySerialization> BinarySerialization for KeyEntry<I> {
     ) -> Result<usize, Error> {
         let mut bytes_written = 0;
         // Write the key
-        let key_len = u16::try_from(self.key.len()).map_err(|_| Error::KeyTooLarge)?;
+        let key_len = u16::try_from(self.key.len()).map_err(|_| ErrorKind::KeyTooLarge)?;
         writer.write_u16::<BigEndian>(key_len)?;
         writer.extend_from_slice(&self.key);
         bytes_written += 2 + key_len as usize;

--- a/nebari/src/tree/mod.rs
+++ b/nebari/src/tree/mod.rs
@@ -53,14 +53,16 @@ use std::{
 
 use byteorder::{BigEndian, ByteOrder};
 use crc::{Crc, CRC_32_BZIP2};
+use parking_lot::MutexGuard;
 
 use crate::{
     chunk_cache::CacheEntry,
+    error::Error,
     io::{FileManager, FileOp, ManagedFile, OpenableFile},
     roots::AbortError,
-    transaction::TransactionManager,
+    transaction::{TransactionHandle, TransactionManager},
     tree::{btree_entry::ScanArgs, state::ActiveState},
-    Buffer, ChunkCache, CompareAndSwapError, Context, Error, Vault,
+    Buffer, ChunkCache, CompareAndSwapError, Context, ErrorKind, Vault,
 };
 
 mod btree_entry;
@@ -108,7 +110,7 @@ pub enum PageHeader {
 }
 
 impl TryFrom<u8> for PageHeader {
-    type Error = Error;
+    type Error = ErrorKind;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -116,7 +118,7 @@ impl TryFrom<u8> for PageHeader {
             1 => Ok(Self::Data),
             2 => Ok(Self::VersionedHeader),
             3 => Ok(Self::UnversionedHeader),
-            _ => Err(Error::data_integrity(format!(
+            _ => Err(ErrorKind::data_integrity(format!(
                 "invalid block header: {}",
                 value
             ))),
@@ -133,7 +135,7 @@ impl TryFrom<u8> for PageHeader {
 ///   limit. Changing this parameter does not automatically rebalance the tree,
 ///   but over time the tree will be updated.
 pub struct TreeFile<Root: root::Root, F: ManagedFile> {
-    file: <F::Manager as FileManager>::FileHandle,
+    pub(crate) file: <F::Manager as FileManager>::FileHandle,
     /// The state of the file.
     pub state: State<Root>,
     vault: Option<Arc<dyn Vault>>,
@@ -168,7 +170,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
         transactions: Option<&TransactionManager<F::Manager>>,
     ) -> Result<Self, Error> {
         let file = context.file_manager.read(path.as_ref())?;
-        Self::initialize_state(&state, path.as_ref(), context, transactions)?;
+        Self::initialize_state(&state, path.as_ref(), file.id(), context, transactions)?;
         Self::new(file, state, context.vault.clone(), context.cache.clone())
     }
 
@@ -180,7 +182,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
         transactions: Option<&TransactionManager<F::Manager>>,
     ) -> Result<Self, Error> {
         let file = context.file_manager.append(path.as_ref())?;
-        Self::initialize_state(&state, path.as_ref(), context, transactions)?;
+        Self::initialize_state(&state, path.as_ref(), file.id(), context, transactions)?;
         Self::new(file, state, context.vault.clone(), context.cache.clone())
     }
 
@@ -188,6 +190,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
     pub fn initialize_state(
         state: &State<Root>,
         file_path: &Path,
+        file_id: Option<u64>,
         context: &Context<F::Manager>,
         transaction_manager: Option<&TransactionManager<F::Manager>>,
     ) -> Result<(), Error> {
@@ -203,6 +206,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
             return Ok(());
         }
 
+        active_state.file_id = file_id;
         let mut file_length = context.file_manager.file_length(file_path)?;
         if file_length == 0 {
             active_state.header.initialize_default();
@@ -265,7 +269,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
                         CacheEntry::Decoded(_) => unreachable!(),
                     };
                     let root = Root::deserialize(contents)
-                        .map_err(|err| Error::DataIntegrity(Box::new(err)))?;
+                        .map_err(|err| ErrorKind::DataIntegrity(Box::new(err)))?;
                     if let Some(transaction_manager) = transaction_manager {
                         if !transaction_manager.transaction_was_successful(root.transaction_id())? {
                             // The transaction wasn't written successfully, so
@@ -455,7 +459,7 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
         ) {
             Ok(_) => Ok(results),
             Err(AbortError::Other(_)) => unreachable!(),
-            Err(AbortError::Roots(error)) => Err(error),
+            Err(AbortError::Nebari(error)) => Err(error),
         }
     }
 
@@ -557,17 +561,32 @@ impl<Root: root::Root, F: ManagedFile> TreeFile<Root, F> {
     /// This process is done atomically by creating a new file containing the
     /// active data. Once the new file has all the current file's data, the file
     /// contents are swapped using atomic file operations.
-    pub fn compact(mut self, file_manager: &F::Manager) -> Result<Self, Error> {
-        let compacted_path = self.file.execute(TreeCompactor {
+    pub fn compact(
+        mut self,
+        file_manager: &F::Manager,
+        transactions: Option<TransactableCompaction<'_, F::Manager>>,
+    ) -> Result<Self, Error> {
+        let (compacted_path, finisher) = self.file.execute(TreeCompactor {
             state: &self.state,
             vault: self.vault.as_deref(),
             cache: self.cache.as_ref(),
             file_manager,
+            transactions,
             scratch: &mut self.scratch,
         })?;
-        self.file = self.file.replace_with(&compacted_path, file_manager)?;
+        self.file = self
+            .file
+            .replace_with(&compacted_path, file_manager, |file_id| {
+                finisher.finish(file_id);
+                println!("Published compaction.");
+            })?;
         Ok(self)
     }
+}
+
+pub struct TransactableCompaction<'a, Manager: FileManager> {
+    pub name: &'a str,
+    pub manager: &'a TransactionManager<Manager>,
 }
 
 struct TreeCompactor<'a, Root: root::Root, M: FileManager> {
@@ -575,37 +594,42 @@ struct TreeCompactor<'a, Root: root::Root, M: FileManager> {
     vault: Option<&'a dyn Vault>,
     cache: Option<&'a ChunkCache>,
     file_manager: &'a M,
+    transactions: Option<TransactableCompaction<'a, M>>,
     scratch: &'a mut Vec<u8>,
 }
 impl<'a, Root: root::Root, F: ManagedFile> FileOp<F> for TreeCompactor<'a, Root, F::Manager> {
-    type Output = Result<PathBuf, Error>;
+    type Output = Result<(PathBuf, TreeCompactionFinisher<'a, Root>), Error>;
 
     fn execute(&mut self, file: &mut F) -> Self::Output {
         let current_path = file.path().to_path_buf();
         let file_name = current_path
             .file_name()
-            .ok_or_else(|| Error::message("could not retrieve file name"))?;
+            .ok_or_else(|| ErrorKind::message("could not retrieve file name"))?;
         let mut compacted_name = file_name.to_os_string();
         compacted_name.push(".compacting");
         let compacted_path = current_path
             .parent()
-            .ok_or_else(|| Error::message("couldn't access parent of file"))?
+            .ok_or_else(|| ErrorKind::message("couldn't access parent of file"))?
             .join(compacted_name);
 
         if compacted_path.exists() {
             std::fs::remove_file(&compacted_path)?;
         }
 
+        let transaction = self.transactions.as_ref().map(|transactions| {
+            transactions
+                .manager
+                .new_transaction(&[transactions.name.as_bytes()])
+        });
         let mut new_file = F::open_for_append(&compacted_path, None)?;
-        let mut writer =
-            PagedWriter::new(PageHeader::Data, &mut new_file, self.vault, self.cache, 0);
+        let mut writer = PagedWriter::new(PageHeader::Data, &mut new_file, self.vault, None, 0);
 
         // Use the read state to list all the currently live chunks
         let mut copied_chunks = HashMap::new();
         let read_state = self.state.read();
         let mut temporary_header = read_state.header.clone();
-        temporary_header.copy_data_to(false, file, &mut copied_chunks, &mut writer, self.vault)?;
         drop(read_state);
+        temporary_header.copy_data_to(false, file, &mut copied_chunks, &mut writer, self.vault)?;
 
         // Now, do the same with the write state, which should be very fast,
         // since only nodes that have changed will need to be visited.
@@ -614,21 +638,34 @@ impl<'a, Root: root::Root, F: ManagedFile> FileOp<F> for TreeCompactor<'a, Root,
             .header
             .copy_data_to(true, file, &mut copied_chunks, &mut writer, self.vault)?;
 
-        save_tree(
-            &mut write_state,
-            self.vault,
-            self.cache,
-            writer,
-            self.scratch,
-        )?;
+        save_tree(&mut write_state, self.vault, None, writer, self.scratch)?;
 
         // Close any existing handles to the file. This ensures that once we
         // save the tree, new requests to the file manager will point to the new
         // file.
-        self.file_manager
-            .close_handles(&current_path, || write_state.publish(self.state));
 
-        Ok(compacted_path)
+        Ok((
+            compacted_path,
+            TreeCompactionFinisher {
+                transaction,
+                write_state,
+                state: self.state,
+            },
+        ))
+    }
+}
+
+struct TreeCompactionFinisher<'a, Root: root::Root> {
+    transaction: Option<TransactionHandle>,
+    state: &'a State<Root>,
+    write_state: MutexGuard<'a, ActiveState<Root>>,
+}
+
+impl<'a, Root: root::Root> TreeCompactionFinisher<'a, Root> {
+    fn finish(mut self, new_file_id: u64) {
+        self.write_state.file_id = Some(new_file_id);
+        self.write_state.publish(self.state);
+        drop(self);
     }
 }
 
@@ -643,6 +680,9 @@ impl<'a, Root: root::Root, F: ManagedFile> FileOp<F> for TreeWriter<'a, Root> {
     type Output = Result<(), Error>;
     fn execute(&mut self, file: &mut F) -> Self::Output {
         let mut active_state = self.state.lock();
+        if active_state.file_id != file.id() {
+            return Err(Error::from(ErrorKind::DatabaseCompacted));
+        }
         if active_state.header.dirty() {
             let data_block = PagedWriter::new(
                 PageHeader::Data,
@@ -679,6 +719,9 @@ impl<'a, 'm, Root: root::Root, F: ManagedFile> FileOp<F> for DocumentWriter<'a, 
 
     fn execute(&mut self, file: &mut F) -> Self::Output {
         let mut active_state = self.state.lock();
+        if active_state.file_id != file.id() {
+            return Err(Error::from(ErrorKind::DatabaseCompacted));
+        }
 
         let mut data_block = PagedWriter::new(
             PageHeader::Data,
@@ -825,6 +868,10 @@ where
     fn execute(&mut self, file: &mut F) -> Self::Output {
         if self.from_transaction {
             let state = self.state.lock();
+            if state.file_id != file.id() {
+                return Err(Error::from(ErrorKind::DatabaseCompacted));
+            }
+
             state.header.get_multiple(
                 &mut self.keys,
                 &mut self.key_evaluator,
@@ -835,6 +882,10 @@ where
             )
         } else {
             let state = self.state.read();
+            if state.file_id != file.id() {
+                return Err(Error::from(ErrorKind::DatabaseCompacted));
+            }
+
             state.header.get_multiple(
                 &mut self.keys,
                 &mut self.key_evaluator,
@@ -878,6 +929,12 @@ where
     fn execute(&mut self, file: &mut F) -> Self::Output {
         if self.from_transaction {
             let state = self.state.lock();
+            if state.file_id != file.id() {
+                return Err(AbortError::Nebari(Error::from(
+                    ErrorKind::DatabaseCompacted,
+                )));
+            }
+
             state.header.scan(
                 &self.range,
                 &mut ScanArgs::new(self.forwards, &mut self.key_evaluator, &mut self.key_reader),
@@ -887,6 +944,12 @@ where
             )
         } else {
             let state = self.state.read();
+            if state.file_id != file.id() {
+                return Err(AbortError::Nebari(Error::from(
+                    ErrorKind::DatabaseCompacted,
+                )));
+            }
+
             state.header.scan(
                 &self.range,
                 &mut ScanArgs::new(self.forwards, &mut self.key_evaluator, &mut self.key_reader),
@@ -1004,7 +1067,8 @@ impl<'a, F: ManagedFile> PagedWriter<'a, F> {
             || Cow::Borrowed(contents),
             |vault| Cow::Owned(vault.encrypt(contents)),
         );
-        let length = u32::try_from(possibly_encrypted.len()).map_err(|_| Error::ValueTooLarge)?;
+        let length =
+            u32::try_from(possibly_encrypted.len()).map_err(|_| ErrorKind::ValueTooLarge)?;
         let crc = CRC32.checksum(&possibly_encrypted);
         let mut position = self.current_position();
         // Ensure that the chunk header can be read contiguously
@@ -1182,7 +1246,9 @@ pub(crate) fn copy_chunk<F: ManagedFile, S: BuildHasher>(
     to_file: &mut PagedWriter<'_, F>,
     vault: Option<&dyn crate::Vault>,
 ) -> Result<u64, Error> {
-    if let Some(new_position) = copied_chunks.get(&original_position) {
+    if original_position == 0 {
+        Ok(0)
+    } else if let Some(new_position) = copied_chunks.get(&original_position) {
         Ok(*new_position)
     } else {
         // Since these are one-time copies, and receiving a Decoded entry
@@ -1280,7 +1346,7 @@ mod tests {
         {
             let state = if ids.len() > 1 {
                 let state = State::default();
-                TreeFile::<R, F>::initialize_state(&state, file_path, context, None).unwrap();
+                TreeFile::<R, F>::initialize_state(&state, file_path, None, context, None).unwrap();
                 state
             } else {
                 State::initialized()
@@ -1300,7 +1366,7 @@ mod tests {
         // Try loading the file up and retrieving the data.
         {
             let state = State::default();
-            TreeFile::<R, F>::initialize_state(&state, file_path, context, None).unwrap();
+            TreeFile::<R, F>::initialize_state(&state, file_path, None, context, None).unwrap();
 
             let file = context.file_manager.append(file_path).unwrap();
             let mut tree =
@@ -1318,9 +1384,10 @@ mod tests {
     ) {
         let id_buffer = Buffer::from(id.to_be_bytes().to_vec());
         {
-            let state = State::default();
-            TreeFile::<R, F>::initialize_state(&state, file_path, context, None).unwrap();
             let file = context.file_manager.append(file_path).unwrap();
+            let state = State::default();
+            TreeFile::<R, F>::initialize_state(&state, file_path, file.id(), context, None)
+                .unwrap();
             let mut tree =
                 TreeFile::<R, F>::new(file, state, context.vault.clone(), context.cache.clone())
                     .unwrap();
@@ -1338,10 +1405,11 @@ mod tests {
 
         // Try loading the file up and retrieving the data.
         {
-            let state = State::default();
-            TreeFile::<R, F>::initialize_state(&state, file_path, context, None).unwrap();
-
             let file = context.file_manager.append(file_path).unwrap();
+            let state = State::default();
+            TreeFile::<R, F>::initialize_state(&state, file_path, file.id(), context, None)
+                .unwrap();
+
             let mut tree =
                 TreeFile::<R, F>::new(file, state, context.vault.clone(), context.cache.clone())
                     .unwrap();
@@ -1598,7 +1666,7 @@ mod tests {
         let mut tree =
             TreeFile::<R, StdFile>::write(&file_path, State::default(), &context, None).unwrap();
         let pre_compact_size = context.file_manager.file_length(&file_path).unwrap();
-        tree = tree.compact(&context.file_manager).unwrap();
+        tree = tree.compact(&context.file_manager, None).unwrap();
         let after_compact_size = context.file_manager.file_length(&file_path).unwrap();
         assert!(
             after_compact_size < pre_compact_size,

--- a/nebari/src/tree/modify.rs
+++ b/nebari/src/tree/modify.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::btree_entry::KeyOperation;
-use crate::{Buffer, Error};
+use crate::{error::Error, Buffer, ErrorKind};
 
 /// A tree modification.
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl<'a, T> Modification<'a, T> {
             }
             Ok(())
         } else {
-            Err(Error::KeysNotOrdered)
+            Err(Error::from(ErrorKind::KeysNotOrdered))
         }
     }
 }

--- a/nebari/src/tree/root.rs
+++ b/nebari/src/tree/root.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use crate::{
+    error::Error,
     io::ManagedFile,
     roots::AnyTransactionTree,
     transaction::TransactionManager,
@@ -16,13 +17,17 @@ use crate::{
         btree_entry::ScanArgs, state::AnyTreeState, KeyEvaluation, KeyRange, Modification,
         PageHeader, PagedWriter, State, TreeFile,
     },
-    AbortError, Buffer, ChunkCache, Context, Error, TransactionTree, Vault,
+    AbortError, Buffer, ChunkCache, Context, TransactionTree, Vault,
 };
 
 /// A B-Tree root implementation.
 pub trait Root: Default + Debug + Send + Sync + Clone + 'static {
     /// The unique header byte for this root.
     const HEADER: PageHeader;
+
+    /// Returns the number of values contained in this tree, not including
+    /// deleted records.
+    fn count(&self) -> u64;
 
     /// Returns a reference to a named tree that contains this type of root.
     fn tree<F: ManagedFile>(name: impl Into<Cow<'static, str>>) -> TreeRoot<F> {

--- a/nebari/src/tree/serialization.rs
+++ b/nebari/src/tree/serialization.rs
@@ -1,5 +1,5 @@
 use super::PagedWriter;
-use crate::{io::ManagedFile, Buffer, Error};
+use crate::{error::Error, io::ManagedFile, Buffer};
 
 pub trait BinarySerialization: Send + Sync + Sized {
     fn serialize_to<F: ManagedFile>(

--- a/nebari/src/tree/state.rs
+++ b/nebari/src/tree/state.rs
@@ -57,6 +57,7 @@ impl<Root: super::Root> AnyTreeState for State<Root> {
 
 #[derive(Clone, Debug, Default)]
 pub struct ActiveState<Root: super::Root> {
+    pub file_id: Option<u64>,
     pub current_position: u64,
     pub header: Root,
 }

--- a/nebari/src/tree/state.rs
+++ b/nebari/src/tree/state.rs
@@ -19,13 +19,19 @@ where
 {
     /// Returns an initialized state. This should only be used if you're
     /// creating a file from scratch.
-    pub fn initialized() -> Self {
-        let state = Self::default();
-        {
-            let mut state = state.lock();
-            state.header.initialize_default();
+    pub fn initialized(file_id: Option<u64>) -> Self {
+        let mut header = Root::default();
+        header.initialize_default();
+        let state = ActiveState {
+            file_id,
+            current_position: 0,
+            header,
+        };
+
+        Self {
+            reader: Arc::new(RwLock::new(state.clone())),
+            writer: Arc::new(Mutex::new(state)),
         }
-        state
     }
 
     /// Locks the state.

--- a/nebari/src/tree/versioned.rs
+++ b/nebari/src/tree/versioned.rs
@@ -60,8 +60,7 @@ pub enum ChangeResult<I: BinarySerialization, R: BinarySerialization> {
 impl VersionedTreeRoot {
     fn modify_sequence_root<'a, 'w, F: ManagedFile>(
         &'a mut self,
-        mut modification: Modification<'_, Buffer<'static>>,
-        changes: &mut EntryChanges,
+        mut modification: Modification<'_, BySequenceIndex>,
         writer: &'a mut PagedWriter<'w, F>,
     ) -> Result<(), Error> {
         // Reverse so that pop is efficient.
@@ -76,9 +75,49 @@ impl VersionedTreeRoot {
                 &mut modification,
                 &ModificationContext {
                     current_order: by_sequence_order,
+                    indexer: |_key: &Buffer<'_>,
+                              value: Option<&BySequenceIndex>,
+                              _existing_index: Option<&BySequenceIndex>,
+                              _changes: &mut EntryChanges,
+                              _writer: &mut PagedWriter<'_, F>| {
+                        Ok(KeyOperation::Set(value.unwrap().clone()))
+                    },
+                    loader: |_index: &BySequenceIndex, _writer: &mut PagedWriter<'_, F>| Ok(None),
+                    _phantom: PhantomData,
+                },
+                None,
+                &mut EntryChanges::default(),
+                writer,
+            )? {
+                ChangeResult::Remove | ChangeResult::Unchanged | ChangeResult::Changed => {}
+                ChangeResult::Split(upper) => {
+                    self.by_sequence_root.split_root(upper);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn modify_id_root<'a, 'w, F: ManagedFile>(
+        &'a mut self,
+        mut modification: Modification<'_, Buffer<'static>>,
+        changes: &mut EntryChanges,
+        writer: &'a mut PagedWriter<'w, F>,
+    ) -> Result<(), Error> {
+        modification.reverse()?;
+
+        let by_id_order = dynamic_order::<MAX_ORDER>(
+            self.by_id_root.stats().total_documents() + modification.keys.len() as u64,
+        );
+
+        while !modification.keys.is_empty() {
+            match self.by_id_root.modify(
+                &mut modification,
+                &ModificationContext {
+                    current_order: by_id_order,
                     indexer: |key: &Buffer<'_>,
                               value: Option<&Buffer<'static>>,
-                              _existing_index: Option<&BySequenceIndex>,
+                              _existing_index: Option<&VersionedByIdIndex>,
                               changes: &mut EntryChanges,
                               writer: &mut PagedWriter<'_, F>| {
                         let (document_position, document_size) = if let Some(value) = value {
@@ -101,13 +140,13 @@ impl VersionedTreeRoot {
                             document_position,
                             document_size,
                         });
-                        Ok(KeyOperation::Set(BySequenceIndex {
-                            document_id: key,
+                        Ok(KeyOperation::Set(VersionedByIdIndex {
+                            sequence_id: changes.current_sequence,
                             position: document_position,
                             document_size,
                         }))
                     },
-                    loader: |index: &BySequenceIndex, writer: &mut PagedWriter<'_, F>| {
+                    loader: |index, writer| {
                         if index.position > 0 {
                             match writer.read_chunk(index.position) {
                                 Ok(CacheEntry::Buffer(buffer)) => Ok(Some(buffer)),
@@ -124,54 +163,14 @@ impl VersionedTreeRoot {
                 changes,
                 writer,
             )? {
-                ChangeResult::Remove | ChangeResult::Unchanged | ChangeResult::Changed => {}
-                ChangeResult::Split(upper) => {
-                    self.by_sequence_root.split_root(upper);
-                }
-            }
-        }
-        self.sequence = changes.current_sequence;
-        Ok(())
-    }
-
-    fn modify_id_root<'a, 'w, F: ManagedFile>(
-        &'a mut self,
-        mut modification: Modification<'_, VersionedByIdIndex>,
-        writer: &'a mut PagedWriter<'w, F>,
-    ) -> Result<(), Error> {
-        modification.reverse()?;
-
-        let by_id_order = dynamic_order::<MAX_ORDER>(
-            self.by_id_root.stats().total_documents() + modification.keys.len() as u64,
-        );
-
-        while !modification.keys.is_empty() {
-            match self.by_id_root.modify(
-                &mut modification,
-                &ModificationContext {
-                    current_order: by_id_order,
-                    indexer: |_key: &Buffer<'_>,
-                              value: Option<&VersionedByIdIndex>,
-                              _existing_index,
-                              _changes,
-                              _writer: &mut PagedWriter<'_, F>| {
-                        Ok(value.map_or(KeyOperation::Remove, |value| {
-                            KeyOperation::Set(value.clone())
-                        }))
-                    },
-                    loader: |_index, _writer| Ok(None),
-                    _phantom: PhantomData,
-                },
-                None,
-                &mut EntryChanges::default(),
-                writer,
-            )? {
                 ChangeResult::Remove | ChangeResult::Changed | ChangeResult::Unchanged => {}
                 ChangeResult::Split(upper) => {
                     self.by_id_root.split_root(upper);
                 }
             }
         }
+
+        self.sequence = changes.current_sequence;
 
         Ok(())
     }
@@ -269,7 +268,7 @@ impl Root for VersionedTreeRoot {
             current_sequence: self.sequence,
             changes: Vec::with_capacity(modification.keys.len()),
         };
-        self.modify_sequence_root(modification, &mut changes, writer)?;
+        self.modify_id_root(modification, &mut changes, writer)?;
 
         // Convert the changes into a modification request for the id root.
         let mut values = Vec::with_capacity(changes.changes.len());
@@ -277,20 +276,21 @@ impl Root for VersionedTreeRoot {
             .changes
             .into_iter()
             .map(|change| {
-                values.push(VersionedByIdIndex {
-                    sequence_id: change.sequence,
+                values.push(BySequenceIndex {
+                    document_id: change.key,
                     document_size: change.document_size,
                     position: change.document_position,
                 });
-                change.key
+                Buffer::from(change.sequence.to_be_bytes())
             })
             .collect();
-        let id_modifications = Modification {
+        let sequence_modifications = Modification {
             transaction_id,
             keys,
             operation: Operation::SetEach(values),
         };
-        self.modify_id_root(id_modifications, writer)?;
+
+        self.modify_sequence_root(sequence_modifications, writer)?;
 
         if transaction_id != 0 {
             self.transaction_id = transaction_id;
@@ -449,7 +449,6 @@ impl Root for VersionedTreeRoot {
             keys,
             operation: Operation::SetEach(indexes),
         };
-        println!("Sequence modification: {:?}", modification);
 
         // This modification copies the `sequence_indexes` into the sequence root.
         self.by_sequence_root.modify(


### PR DESCRIPTION
This adds `Tree::compact` which rewrites the tree using the current thread. Other threads will be able to continue accessing the database while the compaction process is running, with a small blocking window to finish the operation.