### PR TITLE
Add an easy way to switch between MemoryFile/StdFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Breaking Changes
+
+- `ManagedFile` has had its metadata functions moved to a new trait `File` which
+  `ManagedFile` must be an implementor of. This allows `dyn File` to be used
+  internally. As a result, `PagedWriter` no longer takes a file type generic
+  parameter.
+- `ManagedFile` has had its functions `open_for_read` and `open_for_append` have
+  been moved to a new trait, `ManagedFileOpener`.
+- `FileManager::replace_with` now takes the replacement file itself instead of
+  the file's Path.
+
+### Added
+
+- `AnyFileManager` has been added to make it easy to select between memory or
+  standard files at runtime.
+
+### Fixed
+
+- Memory files now can be compacted.
+
 ## v0.2.2
 
 ### Fixed

--- a/nebari/src/io/any.rs
+++ b/nebari/src/io/any.rs
@@ -1,0 +1,251 @@
+use std::{
+    io::{Read, Seek, Write},
+    path::Path,
+};
+
+use crate::io::{
+    fs::{OpenStdFile, StdFile, StdFileManager},
+    memory::{MemoryFile, MemoryFileManager, OpenMemoryFile},
+    FileManager, FileOp, ManagedFile, ManagedFileOpener, OpenableFile, OperableFile,
+};
+
+/// A file that can be either a [`StdFile`] or [`MemoryFile`].
+#[derive(Debug)]
+pub enum AnyFile {
+    /// A file backed by a filesystem.
+    Std(StdFile),
+    /// A simulated file backed by memory.
+    Memory(MemoryFile),
+}
+
+impl ManagedFile for AnyFile {
+    type Manager = AnyFileManager;
+}
+
+impl super::File for AnyFile {
+    fn id(&self) -> Option<u64> {
+        match self {
+            Self::Std(file) => file.id(),
+            Self::Memory(file) => file.id(),
+        }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        match self {
+            Self::Std(file) => file.path(),
+            Self::Memory(file) => file.path(),
+        }
+    }
+
+    fn length(&self) -> Result<u64, crate::Error> {
+        match self {
+            Self::Std(file) => file.length(),
+            Self::Memory(file) => file.length(),
+        }
+    }
+
+    fn close(self) -> Result<(), crate::Error> {
+        match self {
+            Self::Std(file) => file.close(),
+            Self::Memory(file) => file.close(),
+        }
+    }
+}
+
+impl Write for AnyFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Std(file) => file.write(buf),
+            Self::Memory(file) => file.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Std(file) => file.flush(),
+            Self::Memory(file) => file.flush(),
+        }
+    }
+}
+
+impl Read for AnyFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Std(file) => file.read(buf),
+            Self::Memory(file) => file.read(buf),
+        }
+    }
+}
+
+impl Seek for AnyFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::Std(file) => file.seek(pos),
+            Self::Memory(file) => file.seek(pos),
+        }
+    }
+}
+
+/// A file manager that can either be a [`StdFileManager`] or a [`MemoryFileManager`].
+#[derive(Debug, Clone)]
+pub enum AnyFileManager {
+    /// A file manager that uses the filesystem.
+    Std(StdFileManager),
+    /// A simulated file system backed by memory.
+    Memory(MemoryFileManager),
+}
+
+impl AnyFileManager {
+    /// Returns a new filesystem-backed manager.
+    #[must_use]
+    pub fn std() -> Self {
+        Self::Std(StdFileManager::default())
+    }
+
+    /// Returns a new memory-backed manager.
+    #[must_use]
+    pub fn memory() -> Self {
+        Self::Memory(MemoryFileManager::default())
+    }
+}
+
+impl FileManager for AnyFileManager {
+    type File = AnyFile;
+    type FileHandle = AnyFileHandle;
+
+    fn read(&self, path: impl AsRef<std::path::Path>) -> Result<Self::FileHandle, crate::Error> {
+        match self {
+            Self::Std(manager) => manager.read(path).map(AnyFileHandle::Std),
+            Self::Memory(manager) => manager.read(path).map(AnyFileHandle::Memory),
+        }
+    }
+
+    fn append(&self, path: impl AsRef<std::path::Path>) -> Result<Self::FileHandle, crate::Error> {
+        match self {
+            Self::Std(manager) => manager.append(path).map(AnyFileHandle::Std),
+            Self::Memory(manager) => manager.append(path).map(AnyFileHandle::Memory),
+        }
+    }
+
+    fn close_handles<F: FnOnce(u64)>(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        publish_callback: F,
+    ) {
+        match self {
+            Self::Std(manager) => manager.close_handles(path, publish_callback),
+            Self::Memory(manager) => manager.close_handles(path, publish_callback),
+        }
+    }
+
+    fn delete(&self, path: impl AsRef<std::path::Path>) -> Result<bool, crate::Error> {
+        match self {
+            Self::Std(manager) => manager.delete(path),
+            Self::Memory(manager) => manager.delete(path),
+        }
+    }
+
+    fn delete_directory(&self, path: impl AsRef<std::path::Path>) -> Result<(), crate::Error> {
+        match self {
+            Self::Std(manager) => manager.delete_directory(path),
+            Self::Memory(manager) => manager.delete_directory(path),
+        }
+    }
+
+    fn exists(&self, path: impl AsRef<std::path::Path>) -> Result<bool, crate::Error> {
+        match self {
+            Self::Std(manager) => manager.exists(path),
+            Self::Memory(manager) => manager.exists(path),
+        }
+    }
+
+    fn file_length(&self, path: impl AsRef<Path>) -> Result<u64, crate::Error> {
+        match self {
+            Self::Std(manager) => manager.file_length(path),
+            Self::Memory(manager) => manager.file_length(path),
+        }
+    }
+}
+
+impl ManagedFileOpener<AnyFile> for AnyFileManager {
+    fn open_for_read(
+        &self,
+        path: impl AsRef<std::path::Path> + Send,
+        id: Option<u64>,
+    ) -> Result<AnyFile, crate::Error> {
+        match self {
+            AnyFileManager::Std(manager) => manager.open_for_read(path, id).map(AnyFile::Std),
+            AnyFileManager::Memory(manager) => manager.open_for_read(path, id).map(AnyFile::Memory),
+        }
+    }
+
+    fn open_for_append(
+        &self,
+        path: impl AsRef<std::path::Path> + Send,
+        id: Option<u64>,
+    ) -> Result<AnyFile, crate::Error> {
+        match self {
+            AnyFileManager::Std(manager) => manager.open_for_append(path, id).map(AnyFile::Std),
+            AnyFileManager::Memory(manager) => {
+                manager.open_for_append(path, id).map(AnyFile::Memory)
+            }
+        }
+    }
+}
+
+impl Default for AnyFileManager {
+    fn default() -> Self {
+        Self::Std(StdFileManager::default())
+    }
+}
+
+/// A handle to an open file that could be either an [`OpenStdFile`] or an [`OpenMemoryFile`].
+#[derive(Debug)]
+pub enum AnyFileHandle {
+    /// An open file on the filesystem.
+    Std(OpenStdFile),
+    /// An open file in memory.
+    Memory(OpenMemoryFile),
+}
+
+impl OpenableFile<AnyFile> for AnyFileHandle {
+    fn id(&self) -> Option<u64> {
+        match self {
+            AnyFileHandle::Std(file) => file.id(),
+            AnyFileHandle::Memory(file) => file.id(),
+        }
+    }
+
+    fn replace_with<C: FnOnce(u64)>(
+        self,
+        path: &std::path::Path,
+        manager: &<AnyFile as ManagedFile>::Manager,
+        publish_callback: C,
+    ) -> Result<Self, crate::Error> {
+        match (self, manager) {
+            (AnyFileHandle::Std(file), AnyFileManager::Std(manager)) => file
+                .replace_with(path, manager, publish_callback)
+                .map(AnyFileHandle::Std),
+            (AnyFileHandle::Memory(file), AnyFileManager::Memory(manager)) => file
+                .replace_with(path, manager, publish_callback)
+                .map(AnyFileHandle::Memory),
+            _ => Err(crate::Error::from("incompatible file and manager")),
+        }
+    }
+
+    fn close(self) -> Result<(), crate::Error> {
+        match self {
+            AnyFileHandle::Std(file) => file.close(),
+            AnyFileHandle::Memory(file) => file.close(),
+        }
+    }
+}
+
+impl OperableFile<AnyFile> for AnyFileHandle {
+    fn execute<Output, Op: FileOp<Output>>(&mut self, operator: Op) -> Output {
+        match self {
+            AnyFileHandle::Std(file) => file.execute(operator),
+            AnyFileHandle::Memory(file) => file.execute(operator),
+        }
+    }
+}

--- a/nebari/src/io/any.rs
+++ b/nebari/src/io/any.rs
@@ -218,16 +218,21 @@ impl OpenableFile<AnyFile> for AnyFileHandle {
 
     fn replace_with<C: FnOnce(u64)>(
         self,
-        path: &std::path::Path,
+        replacement: AnyFile,
         manager: &<AnyFile as ManagedFile>::Manager,
         publish_callback: C,
     ) -> Result<Self, crate::Error> {
-        match (self, manager) {
-            (AnyFileHandle::Std(file), AnyFileManager::Std(manager)) => file
-                .replace_with(path, manager, publish_callback)
-                .map(AnyFileHandle::Std),
-            (AnyFileHandle::Memory(file), AnyFileManager::Memory(manager)) => file
-                .replace_with(path, manager, publish_callback)
+        match (self, replacement, manager) {
+            (AnyFileHandle::Std(file), AnyFile::Std(replacement), AnyFileManager::Std(manager)) => {
+                file.replace_with(replacement, manager, publish_callback)
+                    .map(AnyFileHandle::Std)
+            }
+            (
+                AnyFileHandle::Memory(file),
+                AnyFile::Memory(replacement),
+                AnyFileManager::Memory(manager),
+            ) => file
+                .replace_with(replacement, manager, publish_callback)
                 .map(AnyFileHandle::Memory),
             _ => Err(crate::Error::from("incompatible file and manager")),
         }

--- a/nebari/src/io/fs.rs
+++ b/nebari/src/io/fs.rs
@@ -9,7 +9,10 @@ use std::{
 use parking_lot::Mutex;
 
 use super::{FileManager, FileOp, ManagedFile, OpenableFile};
-use crate::{error::Error, io::PathIds};
+use crate::{
+    error::Error,
+    io::{File as _, ManagedFileOpener, OperableFile, PathIds},
+};
 
 /// An open file that uses [`std::fs`].
 #[derive(Debug)]
@@ -21,41 +24,15 @@ pub struct StdFile {
 
 impl ManagedFile for StdFile {
     type Manager = StdFileManager;
+}
+
+impl super::File for StdFile {
     fn id(&self) -> Option<u64> {
         self.id
     }
 
     fn path(&self) -> &Path {
         &self.path
-    }
-
-    fn open_for_read(
-        path: impl AsRef<std::path::Path> + Send,
-        id: Option<u64>,
-    ) -> Result<Self, Error> {
-        let path = path.as_ref();
-        Ok(Self {
-            file: File::open(path)?,
-            path: path.to_path_buf(),
-            id,
-        })
-    }
-
-    fn open_for_append(
-        path: impl AsRef<std::path::Path> + Send,
-        id: Option<u64>,
-    ) -> Result<Self, Error> {
-        let path = path.as_ref();
-        Ok(Self {
-            file: OpenOptions::new()
-                .write(true)
-                .append(true)
-                .read(true)
-                .create(true)
-                .open(path)?,
-            path: path.to_path_buf(),
-            id,
-        })
     }
 
     fn length(&self) -> Result<u64, Error> {
@@ -66,6 +43,42 @@ impl ManagedFile for StdFile {
     fn close(mut self) -> Result<(), Error> {
         // Closing is done by just dropping it
         self.flush().map_err(Error::from)
+    }
+}
+
+/// A [`ManagedFileOpener`] implementation that produces [`StdFile`]s.
+pub struct StdFileOpener;
+
+impl ManagedFileOpener<StdFile> for StdFileOpener {
+    fn open_for_read(
+        &self,
+        path: impl AsRef<std::path::Path> + Send,
+        id: Option<u64>,
+    ) -> Result<StdFile, Error> {
+        let path = path.as_ref();
+        Ok(StdFile {
+            file: File::open(path)?,
+            path: path.to_path_buf(),
+            id,
+        })
+    }
+
+    fn open_for_append(
+        &self,
+        path: impl AsRef<std::path::Path> + Send,
+        id: Option<u64>,
+    ) -> Result<StdFile, Error> {
+        let path = path.as_ref();
+        Ok(StdFile {
+            file: OpenOptions::new()
+                .write(true)
+                .append(true)
+                .read(true)
+                .create(true)
+                .open(path)?,
+            path: path.to_path_buf(),
+            id,
+        })
     }
 }
 
@@ -146,7 +159,7 @@ impl FileManager for StdFileManager {
                 manager: Some(self.clone()),
             })
         } else {
-            let file = StdFile::open_for_append(path, Some(file_id))?;
+            let file = self.open_for_append(path, Some(file_id))?;
             open_files.insert(file_id, FileSlot::Taken);
             Ok(OpenStdFile {
                 file: Some(file),
@@ -171,7 +184,7 @@ impl FileManager for StdFileManager {
             });
         }
 
-        let file = StdFile::open_for_read(path, Some(file_id))?;
+        let file = StdFileOpener.open_for_read(path, Some(file_id))?;
         Ok(OpenStdFile {
             file: Some(file),
             manager: Some(self.clone()),
@@ -223,6 +236,35 @@ impl FileManager for StdFileManager {
             publish_callback(result.new_id);
         }
     }
+
+    fn exists(&self, path: impl AsRef<std::path::Path>) -> Result<bool, crate::Error> {
+        Ok(path.as_ref().exists())
+    }
+
+    fn file_length(&self, path: impl AsRef<Path>) -> Result<u64, Error> {
+        path.as_ref()
+            .metadata()
+            .map_err(Error::from)
+            .map(|metadata| metadata.len())
+    }
+}
+
+impl ManagedFileOpener<StdFile> for StdFileManager {
+    fn open_for_read(
+        &self,
+        path: impl AsRef<Path> + Send,
+        id: Option<u64>,
+    ) -> Result<StdFile, Error> {
+        StdFileOpener.open_for_read(path, id)
+    }
+
+    fn open_for_append(
+        &self,
+        path: impl AsRef<Path> + Send,
+        id: Option<u64>,
+    ) -> Result<StdFile, Error> {
+        StdFileOpener.open_for_append(path, id)
+    }
 }
 
 /// An open [`StdFile`] that belongs to a [`StdFileManager`].
@@ -236,10 +278,6 @@ pub struct OpenStdFile {
 impl OpenableFile<StdFile> for OpenStdFile {
     fn id(&self) -> Option<u64> {
         self.file.as_ref().and_then(StdFile::id)
-    }
-
-    fn execute<W: FileOp<StdFile>>(&mut self, writer: W) -> W::Output {
-        writer.execute(self.file.as_mut().unwrap())
     }
 
     fn replace_with<C: FnOnce(u64)>(
@@ -259,6 +297,12 @@ impl OpenableFile<StdFile> for OpenStdFile {
     fn close(self) -> Result<(), Error> {
         drop(self);
         Ok(())
+    }
+}
+
+impl OperableFile<StdFile> for OpenStdFile {
+    fn execute<Output, Op: FileOp<Output>>(&mut self, operator: Op) -> Output {
+        operator.execute(self.file.as_mut().unwrap())
     }
 }
 

--- a/nebari/src/transaction/manager.rs
+++ b/nebari/src/transaction/manager.rs
@@ -12,7 +12,7 @@ use parking_lot::Mutex;
 use super::{log::EntryFetcher, LogEntry, State, TransactionLog};
 use crate::{
     error::{Error, InternalError},
-    io::{FileManager, ManagedFile, OpenableFile},
+    io::{FileManager, ManagedFile, OperableFile},
     transaction::log::ScanResult,
     Context, ErrorKind,
 };
@@ -25,7 +25,10 @@ pub struct TransactionManager<Manager: FileManager> {
     context: Context<Manager>,
 }
 
-impl<Manager: FileManager> TransactionManager<Manager> {
+impl<Manager> TransactionManager<Manager>
+where
+    Manager: FileManager,
+{
     /// Spawns a new transaction manager. The transaction manager runs its own
     /// thread that writes to the transaction log.
     pub fn spawn(directory: &Path, context: Context<Manager>) -> Result<Self, Error> {

--- a/nebari/src/tree/by_id.rs
+++ b/nebari/src/tree/by_id.rs
@@ -1,7 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use super::{btree_entry::Reducer, BinarySerialization, PagedWriter};
-use crate::{error::Error, io::ManagedFile, tree::key_entry::ValueIndex, ArcBytes};
+use crate::{error::Error, tree::key_entry::ValueIndex, ArcBytes};
 
 /// The index stored within [`VersionedTreeRoot::by_id_root`](crate::tree::VersionedTreeRoot::by_id_root).
 #[derive(Clone, Debug)]
@@ -20,10 +20,10 @@ impl<EmbeddedIndex> BinarySerialization for VersionedByIdIndex<EmbeddedIndex>
 where
     EmbeddedIndex: super::EmbeddedIndex,
 {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         writer.write_u64::<BigEndian>(self.sequence_id)?;
         writer.write_u32::<BigEndian>(self.value_length)?;
@@ -68,10 +68,10 @@ impl<EmbeddedIndex> BinarySerialization for UnversionedByIdIndex<EmbeddedIndex>
 where
     EmbeddedIndex: super::EmbeddedIndex,
 {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         writer.write_u32::<BigEndian>(self.value_length)?;
         writer.write_u64::<BigEndian>(self.position)?;
@@ -123,10 +123,10 @@ impl<EmbeddedStats> BinarySerialization for ByIdStats<EmbeddedStats>
 where
     EmbeddedStats: super::Serializable,
 {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         writer.write_u64::<BigEndian>(self.alive_keys)?;
         writer.write_u64::<BigEndian>(self.deleted_keys)?;

--- a/nebari/src/tree/by_sequence.rs
+++ b/nebari/src/tree/by_sequence.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use super::{btree_entry::Reducer, BinarySerialization, PagedWriter};
-use crate::{error::Error, io::ManagedFile, tree::key_entry::ValueIndex, ArcBytes, ErrorKind};
+use crate::{error::Error, tree::key_entry::ValueIndex, ArcBytes, ErrorKind};
 
 /// The index stored within [`VersionedTreeRoot::by_sequence_root`](crate::tree::VersionedTreeRoot::by_sequence_root).
 #[derive(Clone, Debug)]
@@ -19,10 +19,10 @@ pub struct BySequenceIndex {
 }
 
 impl BinarySerialization for BySequenceIndex {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         let mut bytes_written = 0;
         writer.write_u32::<BigEndian>(self.value_length)?;
@@ -84,10 +84,10 @@ pub struct BySequenceStats {
 }
 
 impl BinarySerialization for BySequenceStats {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         writer.write_u64::<BigEndian>(self.total_sequences)?;
         Ok(8)

--- a/nebari/src/tree/serialization.rs
+++ b/nebari/src/tree/serialization.rs
@@ -1,11 +1,11 @@
 use super::PagedWriter;
-use crate::{error::Error, io::ManagedFile, ArcBytes};
+use crate::{error::Error, ArcBytes};
 
 pub trait BinarySerialization: Send + Sync + Sized {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         writer: &mut Vec<u8>,
-        paged_writer: &mut PagedWriter<'_, File>,
+        paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error>;
     fn deserialize_from(
         reader: &mut ArcBytes<'_>,
@@ -14,10 +14,10 @@ pub trait BinarySerialization: Send + Sync + Sized {
 }
 
 impl BinarySerialization for () {
-    fn serialize_to<File: ManagedFile>(
+    fn serialize_to(
         &mut self,
         _writer: &mut Vec<u8>,
-        _paged_writer: &mut PagedWriter<'_, File>,
+        _paged_writer: &mut PagedWriter<'_>,
     ) -> Result<usize, Error> {
         Ok(0)
     }


### PR DESCRIPTION
Refs khonsulabs/bonsaidb#169

This introduces the `AnyFile` and `AnyFileManager` types which allow selecting whether to use MemoryFiles or StdFiles at runtime.