### PR TITLE
Use the edition 2021 resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["nebari", "xtask", "benchmarks", "fuzz"]
+resolver = "2"


### PR DESCRIPTION
Cargo says when building:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

This PR sets the workspace to use the edition 2021 resolver instead of the old one.