### PR TITLE
Use empty match to handle Infallible

### DIFF
--- a/nebari/src/roots.rs
+++ b/nebari/src/roots.rs
@@ -1576,7 +1576,7 @@ impl AbortError<Infallible> {
     #[must_use]
     pub fn infallible(self) -> Error {
         match self {
-            AbortError::Other(_) => unreachable!(),
+            AbortError::Other(infallible) => match infallible {},
             AbortError::Nebari(error) => error,
         }
     }


### PR DESCRIPTION
Empty `enum`s like `Infallible` can be used in an empty `match` expression, avoiding the use of `unreachable!()`.