### PR TITLE
Make `Tree` methods take `&self` rather than `&mut self`

### DIFF
--- a/nebari/src/io/any.rs
+++ b/nebari/src/io/any.rs
@@ -217,17 +217,13 @@ impl OpenableFile<AnyFile> for AnyFileHandle {
         publish_callback: C,
     ) -> Result<Self, crate::Error> {
         match (self, replacement, manager) {
-            (Self::Std(file), AnyFile::Std(replacement), AnyFileManager::Std(manager)) => {
-                file.replace_with(replacement, manager, publish_callback)
-                    .map(AnyFileHandle::Std)
-            }
-            (
-                Self::Memory(file),
-                AnyFile::Memory(replacement),
-                AnyFileManager::Memory(manager),
-            ) => file
+            (Self::Std(file), AnyFile::Std(replacement), AnyFileManager::Std(manager)) => file
                 .replace_with(replacement, manager, publish_callback)
-                .map(AnyFileHandle::Memory),
+                .map(AnyFileHandle::Std),
+            (Self::Memory(file), AnyFile::Memory(replacement), AnyFileManager::Memory(manager)) => {
+                file.replace_with(replacement, manager, publish_callback)
+                    .map(AnyFileHandle::Memory)
+            }
             _ => Err(crate::Error::from("incompatible file and manager")),
         }
     }

--- a/nebari/src/roots.rs
+++ b/nebari/src/roots.rs
@@ -1037,7 +1037,7 @@ impl<Root: tree::Root, File: ManagedFile> Tree<Root, File> {
     /// - The new/updated index for this key.
     #[allow(clippy::missing_panics_doc)]
     pub fn replace(
-        &mut self,
+        &self,
         key: impl Into<ArcBytes<'static>>,
         value: impl Into<Root::Value>,
     ) -> Result<(Option<Root::Value>, Root::Index), Error> {
@@ -1050,7 +1050,7 @@ impl<Root: tree::Root, File: ManagedFile> Tree<Root, File> {
     /// Executes a modification. Returns a list of all changed keys.
     #[allow(clippy::missing_panics_doc)]
     pub fn modify<'a>(
-        &mut self,
+        &self,
         keys: Vec<ArcBytes<'a>>,
         operation: Operation<'a, Root::Value, Root::Index>,
     ) -> Result<Vec<ModificationResult<Root::Index>>, Error> {
@@ -1494,7 +1494,7 @@ where
     /// the value was removed, None is returned for the value.
     #[allow(clippy::needless_pass_by_value)]
     pub fn get_multiple_by_sequence<Sequences>(
-        &mut self,
+        &self,
         sequences: Sequences,
     ) -> Result<HashMap<SequenceId, (ArcBytes<'static>, Option<ArcBytes<'static>>)>, Error>
     where
@@ -1517,7 +1517,7 @@ where
     /// If a sequence is not found, it will not appear in the result list.
     #[allow(clippy::needless_pass_by_value)]
     pub fn get_multiple_indexes_by_sequence<Sequences>(
-        &mut self,
+        &self,
         sequences: Sequences,
     ) -> Result<Vec<SequenceIndex<Index>>, Error>
     where
@@ -1541,7 +1541,7 @@ where
     /// result list.
     #[allow(clippy::needless_pass_by_value)]
     pub fn get_multiple_with_indexes_by_sequence<Sequences>(
-        &mut self,
+        &self,
         sequences: Sequences,
     ) -> Result<HashMap<SequenceId, SequenceEntry<Index>>, Error>
     where
@@ -1576,8 +1576,8 @@ impl AbortError<Infallible> {
     #[must_use]
     pub fn infallible(self) -> Error {
         match self {
-            AbortError::Other(infallible) => match infallible {},
-            AbortError::Nebari(error) => error,
+            Self::Other(infallible) => match infallible {},
+            Self::Nebari(error) => error,
         }
     }
 }

--- a/nebari/src/tree/mod.rs
+++ b/nebari/src/tree/mod.rs
@@ -1671,9 +1671,7 @@ where
             }
 
             state.root.by_sequence_root.get_multiple(
-                &mut self
-                    .keys
-                    .map(|sequence| sequence.0.to_be_bytes()),
+                &mut self.keys.map(|sequence| sequence.0.to_be_bytes()),
                 |key, index| {
                     (self.key_evaluator)(SequenceId::try_from(key.as_slice()).unwrap(), index)
                 },
@@ -1691,9 +1689,7 @@ where
             }
 
             state.root.by_sequence_root.get_multiple(
-                &mut self
-                    .keys
-                    .map(|sequence| sequence.0.to_be_bytes()),
+                &mut self.keys.map(|sequence| sequence.0.to_be_bytes()),
                 |key, index| {
                     (self.key_evaluator)(SequenceId::try_from(key.as_slice()).unwrap(), index)
                 },


### PR DESCRIPTION
I noticed that a few of `Tree`'s methods take `&mut self` instead of `&self` when they don't need to.

(Also, for my previous clippy PR: I re-added a fix from it and ran `cargo fmt` as I think I forgot to then)